### PR TITLE
Install packages for dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ windows-latest, ubuntu-latest, macos-latest ]
+        os: [ windows-latest ]
     steps:
     - name: Checkout branch
       uses: actions/checkout@v2

--- a/VisionCore/VisionCore.csproj
+++ b/VisionCore/VisionCore.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="libtorch-cuda-11.3-win-x64" Version="1.10.0.1" />
+      <PackageReference Include="libtorch-cuda-11.1-win-x64" Version="1.9.0.11" />
       <PackageReference Include="OpenCvSharp4" Version="4.5.3.20210817" />
       <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.5.3.20210817" />
       <PackageReference Include="OpenCvSharp4.Windows" Version="4.5.3.20210817" />

--- a/VisionCore/VisionCore.csproj
+++ b/VisionCore/VisionCore.csproj
@@ -6,6 +6,9 @@
 
     <ItemGroup>
       <PackageReference Include="libtorch-cuda-11.3-win-x64" Version="1.10.0.1" />
+      <PackageReference Include="OpenCvSharp4" Version="4.5.3.20210817" />
+      <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.5.3.20210817" />
+      <PackageReference Include="OpenCvSharp4.Windows" Version="4.5.3.20210817" />
       <PackageReference Include="TorchSharp" Version="0.95.3" />
     </ItemGroup>
 

--- a/VisionCore/VisionCore.csproj
+++ b/VisionCore/VisionCore.csproj
@@ -4,4 +4,9 @@
         <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="libtorch-cuda-11.3-win-x64" Version="1.10.0.1" />
+      <PackageReference Include="TorchSharp" Version="0.95.3" />
+    </ItemGroup>
+
 </Project>

--- a/VisionCore/VisionCore.csproj
+++ b/VisionCore/VisionCore.csproj
@@ -5,6 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="DlibDotNet.CUDA111" Version="19.21.0.20210302" />
       <PackageReference Include="libtorch-cuda-11.1-win-x64" Version="1.9.0.11" />
       <PackageReference Include="OpenCvSharp4" Version="4.5.3.20210817" />
       <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.5.3.20210817" />


### PR DESCRIPTION
This revision includes:
- Install packages for dependency (Resolves #5)
  - TorchSharp
  - OpenCvSharp4
  - DlibDotNet
- Remove 'ubuntu-latest' and 'macos-latest' temporarily
  - Currently, TorchSharp and OpenCvSharp4 works Windows only